### PR TITLE
fix: logo grid layout, use percent instead of fr

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -174,7 +174,7 @@ img.circle {
 
 .logos {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 50% 50%;
     justify-content: space-around;
     align-content: center;
 


### PR DESCRIPTION
Not sure why fr doesn't work:


Before: 1fr 1fr
<img width="1494" alt="Screenshot 2025-05-14 at 16 08 58" src="https://github.com/user-attachments/assets/750fa1c1-481f-4f3e-8953-42831979452b" />


After: 50% 50%

<img width="1250" alt="Screenshot 2025-05-14 at 16 09 50" src="https://github.com/user-attachments/assets/f2848843-f7fa-4de1-8ea3-ec5b93b5fa7a" />
